### PR TITLE
fix possibility of dead lock in ProcessStart

### DIFF
--- a/ModernRonin.ProjectRenamer/Executor.cs
+++ b/ModernRonin.ProjectRenamer/Executor.cs
@@ -26,7 +26,7 @@ namespace ModernRonin.ProjectRenamer
         {
             var result = string.Empty;
             _runtime.DoWithTool(tool, arguments, onNonZeroExitCode, psi => psi.RedirectStandardOutput = true,
-                p => result = p.StandardOutput.ReadToEnd());
+                p => result = p);
             return result;
         }
     }

--- a/ModernRonin.ProjectRenamer/IRuntime.cs
+++ b/ModernRonin.ProjectRenamer/IRuntime.cs
@@ -11,6 +11,6 @@ namespace ModernRonin.ProjectRenamer
             string arguments,
             Action onNonZeroExitCode,
             Action<ProcessStartInfo> configure,
-            Action<Process> onSuccess);
+            Action<string> onSuccess);
     }
 }

--- a/ModernRonin.ProjectRenamer/Runtime.cs
+++ b/ModernRonin.ProjectRenamer/Runtime.cs
@@ -17,7 +17,7 @@ namespace ModernRonin.ProjectRenamer
             string arguments,
             Action onNonZeroExitCode,
             Action<ProcessStartInfo> configure,
-            Action<Process> onSuccess)
+            Action<string> onSuccess)
         {
             var psi = new ProcessStartInfo
             {
@@ -30,9 +30,13 @@ namespace ModernRonin.ProjectRenamer
             try
             {
                 var process = Process.Start(psi);
+                string output = "";
+                if (psi.RedirectStandardOutput)
+                    output = process.StandardOutput.ReadToEnd();
+
                 process.WaitForExit();
                 if (process.ExitCode != 0) onNonZeroExitCode();
-                else onSuccess(process);
+                else onSuccess(output);
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
Calling StandardOutput.ReadToEnd() after WaitForExit can cause a deadlock.
see: https://stackoverflow.com/a/139604/7335274

I found the bug when I tried to use ProjectRenamer in a large project with many references between each other.