### PR TITLE
Add vbproj suport

### DIFF
--- a/ModernRonin.ProjectRenamer/Application.cs
+++ b/ModernRonin.ProjectRenamer/Application.cs
@@ -53,7 +53,7 @@ namespace ModernRonin.ProjectRenamer
                 : Path.GetDirectoryName(oldDir);
             var newDir = _configuration.NewProjectName.ToAbsolutePath(newBase);
             var newFileName = Path.GetFileName(_configuration.NewProjectName);
-            var newProjectPath = Path.Combine(newDir, $"{newFileName}{Constants.ProjectFileExtension}");
+            var newProjectPath = Path.Combine(newDir, $"{newFileName}{_configuration.ProjectFileExtension}");
             var isPaketUsed = _filesystem.DoesDirectoryExist(".paket");
             var gitVersion = _git.GetVersion();
             if (!_configuration.DontReviewSettings)
@@ -231,7 +231,7 @@ namespace ModernRonin.ProjectRenamer
 
                 return all.Except(excluded).ToArray();
 
-                string[] filesIn(string directory) => _filesystem.FindProjectFiles(directory, true);
+                string[] filesIn(string directory) => _filesystem.FindProjectFiles(directory, true, _configuration.ProjectFileExtension);
             }
         }
 

--- a/ModernRonin.ProjectRenamer/Configuration.cs
+++ b/ModernRonin.ProjectRenamer/Configuration.cs
@@ -9,5 +9,6 @@
         public string ExcludedDirectory { get; set; } = string.Empty;
         public string NewProjectName { get; set; }
         public string OldProjectName { get; set; }
+        public string ProjectFileExtension { get; set; } = Constants.ProjectFileExtension;
     }
 }

--- a/ModernRonin.ProjectRenamer/ConfigurationSetup.cs
+++ b/ModernRonin.ProjectRenamer/ConfigurationSetup.cs
@@ -44,8 +44,8 @@ namespace ModernRonin.ProjectRenamer
                             $"Do not specify paths for input/'old' project names, please.{Environment.NewLine}{Environment.NewLine}{helpOverview}");
                     }
 
-                    configuration.OldProjectName = RemoveProjectFileExtension(configuration.OldProjectName);
-                    configuration.NewProjectName = RemoveProjectFileExtension(configuration.NewProjectName);
+                    configuration.OldProjectName = RemoveProjectFileExtension(configuration.OldProjectName, configuration.ProjectFileExtension);
+                    configuration.NewProjectName = RemoveProjectFileExtension(configuration.NewProjectName, configuration.ProjectFileExtension);
 
                     return (configuration, solutionPath);
                 default:
@@ -97,12 +97,18 @@ namespace ModernRonin.ProjectRenamer
                 .WithShortName("e")
                 .WithHelp(
                     "exclude this directory from project reference updates; must be a relative path to the current directory");
+            cfg.Parameter(c => c.ProjectFileExtension)
+                .MakeOptional()
+                .WithLongName("project-extension")
+                .WithShortName("pe")
+                .ExpectAt(3)
+                .WithHelp("the file extension for the project, ex: .csproj, .vbproj");
             return (parser.HelpOverview, parser.Parse(args));
         }
 
-        static string RemoveProjectFileExtension(string projectName) =>
-            projectName.EndsWith(Constants.ProjectFileExtension, StringComparison.InvariantCultureIgnoreCase)
-                ? projectName[..^Constants.ProjectFileExtension.Length]
+        static string RemoveProjectFileExtension(string projectName, string projectFileExtension) =>
+            projectName.EndsWith(projectFileExtension, StringComparison.InvariantCultureIgnoreCase)
+                ? projectName[..^projectFileExtension.Length]
                 : projectName;
     }
 }

--- a/ModernRonin.ProjectRenamer/Executor.cs
+++ b/ModernRonin.ProjectRenamer/Executor.cs
@@ -26,7 +26,7 @@ namespace ModernRonin.ProjectRenamer
         {
             var result = string.Empty;
             _runtime.DoWithTool(tool, arguments, onNonZeroExitCode, psi => psi.RedirectStandardOutput = true,
-                p => result = p.StandardOutput.ReadToEnd());
+                p => result = p);
             return result;
         }
     }

--- a/ModernRonin.ProjectRenamer/Filesystem.cs
+++ b/ModernRonin.ProjectRenamer/Filesystem.cs
@@ -9,9 +9,9 @@ namespace ModernRonin.ProjectRenamer
         public bool DoesDirectoryExist(string directory) => Directory.Exists(directory);
         public void EnsureDirectoryExists(string directory) => Directory.CreateDirectory(directory);
 
-        public string[] FindProjectFiles(string directory, bool doRecurse) =>
+        public string[] FindProjectFiles(string directory, bool doRecurse, string projectFileExtension) =>
             Directory
-                .EnumerateFiles(directory, $"*{Constants.ProjectFileExtension}", SearchOption(doRecurse))
+                .EnumerateFiles(directory, $"*{projectFileExtension}", SearchOption(doRecurse))
                 .ToArray();
 
         public string[] FindSolutionFiles(string directory, bool doRecurse) =>

--- a/ModernRonin.ProjectRenamer/IFilesystem.cs
+++ b/ModernRonin.ProjectRenamer/IFilesystem.cs
@@ -5,7 +5,7 @@
         string CurrentDirectory { get; }
         bool DoesDirectoryExist(string directory);
         void EnsureDirectoryExists(string directory);
-        string[] FindProjectFiles(string directory, bool doRecurse);
+        string[] FindProjectFiles(string directory, bool doRecurse, string projectFileExtension);
         string[] FindSolutionFiles(string directory, bool doRecurse);
     }
 }

--- a/ModernRonin.ProjectRenamer/IRuntime.cs
+++ b/ModernRonin.ProjectRenamer/IRuntime.cs
@@ -11,6 +11,6 @@ namespace ModernRonin.ProjectRenamer
             string arguments,
             Action onNonZeroExitCode,
             Action<ProcessStartInfo> configure,
-            Action<Process> onSuccess);
+            Action<string> onSuccess);
     }
 }

--- a/ModernRonin.ProjectRenamer/Properties/launchSettings.json
+++ b/ModernRonin.ProjectRenamer/Properties/launchSettings.json
@@ -5,6 +5,11 @@
       "commandLineArgs": "LibraryInSolutionFolder ProjectInSolutionFolder",
       "workingDirectory": "C:\\Projects\\Github\\ProjectRenamerTestBed"
     },
+    "rename library to project, in solution folder, .vbproj": {
+      "commandName": "Project",
+      "commandLineArgs": "LibraryInSolutionFolder ProjectInSolutionFolder --project-extension=.vbproj",
+      "workingDirectory": "C:\\Projects\\Github\\ProjectRenamerTestBed"
+    },
     "rename project to library, in solution folder, no review": {
       "commandName": "Project",
       "commandLineArgs": "ProjectInSolutionFolder LibraryInSolutionFolder --no-review",

--- a/ModernRonin.ProjectRenamer/Runtime.cs
+++ b/ModernRonin.ProjectRenamer/Runtime.cs
@@ -17,7 +17,7 @@ namespace ModernRonin.ProjectRenamer
             string arguments,
             Action onNonZeroExitCode,
             Action<ProcessStartInfo> configure,
-            Action<Process> onSuccess)
+            Action<string> onSuccess)
         {
             var psi = new ProcessStartInfo
             {
@@ -30,9 +30,13 @@ namespace ModernRonin.ProjectRenamer
             try
             {
                 var process = Process.Start(psi);
+                string output = "";
+                if (psi.RedirectStandardOutput)
+                    output = process.StandardOutput.ReadToEnd();
+
                 process.WaitForExit();
                 if (process.ExitCode != 0) onNonZeroExitCode();
-                else onSuccess(process);
+                else onSuccess(output);
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
Added support for .vbproj (or any other) file extension project.
Now you can pass the --project-extension (-pe) argument with the project file extension, ex: --project-extension=.vbproj.

the default project file extension is .csproj as always was.

This resolves the soft limitation: 'you cannot use this with projects of other types than csproj, for example fsproj'

Tested with a solution of .vbproj projects